### PR TITLE
Automatically Run CI for Push and PRs + Pin Torch and Brevitas version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,14 @@
 name: CI
 
 on: 
-  # push:
-  # pull_request:
+  push:
+  pull_request:
   workflow_dispatch:
+
+# JUNGVI: Create a concurrency group per branch such that only the latest commit on a branch runs workflows
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
     {name = "Federico Brancasi", email = "fbrancasi@ethz.ch"},
 ]
 dependencies = [
-    "torch>=2.1.2",
+    "torch==2.1.2",
     "torchvision>=0.16.2",
     "torchaudio>=2.1.2",
     "brevitas==0.11.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "torch>=2.1.2",
     "torchvision>=0.16.2",
     "torchaudio>=2.1.2",
-    "brevitas>=0.11.0",
+    "brevitas==0.11.0",
     "torchmetrics",
     "black",
     "isort",


### PR DESCRIPTION
I think that due to the lack of engineering, we need to pin a specific version of Torch and Brevitas to prevent the tool from randomly breaking with dependency updates. I will open an issue to discuss it